### PR TITLE
shared_lib: Internally cache generated protobuf sources

### DIFF
--- a/src/message/CMakeLists.txt
+++ b/src/message/CMakeLists.txt
@@ -1,16 +1,18 @@
 find_package(Protobuf REQUIRED)
 include_directories($PROTOBUF_INCLUDE_DIRS})
 file(GLOB PROTO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.proto")
-PROTOBUF_GENERATE_CPP(PROTO_SRC PROTO_HDRS ${PROTO_FILES})
+PROTOBUF_GENERATE_CPP(RDMA_MGR_PROTO_SRC PROTO_HDRS ${PROTO_FILES})
 set(NET_MESSAGE_SRC
   MessageTypes.h
   ) # Adding headers required for portability reasons http://voices.canonical.com/jussi.pakkanen/2013/03/26/a-list-of-common-cmake-antipatterns/
 
 
-set(ProtobufIncludePath ${CMAKE_CURRENT_BINARY_DIR}
-  CACHE INTERNAL "Path to generated protobuf files.")
+set(RDMAMgrProtobufIncludePath ${CMAKE_CURRENT_BINARY_DIR}
+  CACHE INTERNAL "Path to generated protobuf files of rdma manager.")
 
-add_library(net_message ${NET_MESSAGE_SRC} ${PROTO_SRC} ${PROTO_HDRS})
+set(RDMA_MGR_PROTO_SRC ${RDMA_MGR_PROTO_SRC} CACHE INTERNAL "Generated rdma manager protobuf source files")
+
+add_library(net_message ${NET_MESSAGE_SRC} ${RDMA_MGR_PROTO_SRC} ${PROTO_HDRS})
 target_include_directories(net_message PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(net_message
   ${PROTOBUF_LIBRARIES}


### PR DESCRIPTION
Necessary as building DPI parent module must know their
location to include them into the shared library.

Also minor naming tweaks to avoid name confusion in parent modules