### PR TITLE
Fix compilation issues on aarch64

### DIFF
--- a/perftest/RPCPerf.cc
+++ b/perftest/RPCPerf.cc
@@ -94,7 +94,11 @@ void rdma::RPCPerfThread::poll()  {
 
         while(ft->ret == -1){
             //std::cout << "Waiting for receive" << i << std::endl;
+#ifdef __x86_64__
             __asm__("pause");
+#else
+            usleep(0);
+#endif
         }
         //ft->ret = -1;
 

--- a/src/rdma/ReliableRDMA.h
+++ b/src/rdma/ReliableRDMA.h
@@ -122,7 +122,7 @@ class ReliableRDMA : public BaseRDMA {
     sr.num_sge = 1;
     sr.opcode = IBV_WR_RDMA_WRITE;
     sr.next = nullptr;
-    sr.send_flags = (IBV_SEND_SIGNALED | (size < Config::MAX_RC_INLINE_SEND ? IBV_SEND_INLINE : 0);
+    sr.send_flags = (IBV_SEND_SIGNALED | (size < Config::MAX_RC_INLINE_SEND ? IBV_SEND_INLINE : 0));
     sr.wr.rdma.remote_addr = remoteConn.buffer + offset;
     sr.wr.rdma.rkey = remoteConn.rc.rkey;
     sr.wr_id = wrId;


### PR DESCRIPTION
* Fixes missing ')' in ReliableRDMA.h
* uses x86_64 specific "pause" assembly instruction only if on x86_64 and usleep(0) otherwise