### PR TITLE
Add gid index in config and use it when specified.  

### DIFF
--- a/src/rdma/BaseRDMA.cc
+++ b/src/rdma/BaseRDMA.cc
@@ -96,8 +96,7 @@ void BaseRDMA::createBuffer() {
   
   if (!found)
   {
-    // this code is not executed because ib_dev is nullptr
-    throw runtime_error("Did not find a device connected to specified numa node: " + std::to_string(m_numaNode) + " (Sat in Config::RDMA_NUMAREGION or constructor)");
+    throw runtime_error("Did not find a device connected to specified numa node: " + std::to_string(m_numaNode) + " (Set in Config::RDMA_NUMAREGION or constructor)");
   }
 
   if (!Filehelper::isDirectory(Config::RDMA_DEVICE_FILE_PATH + "/device/net/" + Config::RDMA_INTERFACE))

--- a/src/rdma/BaseRDMA.cc
+++ b/src/rdma/BaseRDMA.cc
@@ -96,7 +96,7 @@ void BaseRDMA::createBuffer() {
   
   if (!found)
   {
-    throw runtime_error("Did not find a device connected to specified numa node: " + std::to_string(m_numaNode) + " (Set in Config::RDMA_NUMAREGION or constructor)");
+    throw runtime_error("Did not find a device connected to specified numa node: " + std::to_string(m_numaNode) + " (Sat in Config::RDMA_NUMAREGION or constructor)");
   }
 
   if (!Filehelper::isDirectory(Config::RDMA_DEVICE_FILE_PATH + "/device/net/" + Config::RDMA_INTERFACE))

--- a/src/rdma/BaseRDMA.cc
+++ b/src/rdma/BaseRDMA.cc
@@ -25,7 +25,7 @@ BaseRDMA::BaseRDMA(size_t mem_size) : BaseRDMA(mem_size, (int)Config::RDMA_NUMAR
 BaseRDMA::BaseRDMA(size_t mem_size, int numaNode) : m_numaNode(numaNode) {
   m_memSize = mem_size;
   m_ibPort = Config::RDMA_IBPORT;
-  m_gidIdx = -1;
+  m_gidIdx = Config::RDMA_GID_INDEX;
   m_rdmaMem.push_back(rdma_mem_t(m_memSize, true, 0));
 
   createBuffer();
@@ -96,6 +96,7 @@ void BaseRDMA::createBuffer() {
   
   if (!found)
   {
+    // this code is not executed because ib_dev is nullptr
     throw runtime_error("Did not find a device connected to specified numa node: " + std::to_string(m_numaNode) + " (Sat in Config::RDMA_NUMAREGION or constructor)");
   }
 

--- a/src/rdma/ReliableRDMA.cc
+++ b/src/rdma/ReliableRDMA.cc
@@ -64,6 +64,9 @@ void ReliableRDMA::initQPWithSuppliedID(const rdmaConnID rdmaConnID) {
   struct ib_conn_t localConn;
   union ibv_gid my_gid;
   memset(&my_gid, 0, sizeof my_gid);
+  // context, port_num, index, gid
+  if (m_gidIdx != -1 && m_gidIdx <= m_res.port_attr.gid_tbl_len)
+    ibv_query_gid(m_res.ib_ctx, m_ibPort, m_gidIdx, &my_gid);
 
   localConn.buffer = (uint64_t)m_res.buffer;
   localConn.rc.rkey = m_res.mr->rkey;
@@ -93,6 +96,9 @@ void ReliableRDMA::initQPWithSuppliedID(struct ib_qp_t** qp ,struct ib_conn_t **
     //struct ib_conn_t localConn;
     union ibv_gid my_gid;
     memset(&my_gid, 0, sizeof my_gid);
+    // context, port_num, index, gid
+    if (m_gidIdx != -1 && m_gidIdx <= m_res.port_attr.gid_tbl_len)
+        ibv_query_gid(m_res.ib_ctx, m_ibPort, m_gidIdx, &my_gid);
 
     (*localConn)->buffer = (uint64_t)m_res.buffer;
     (*localConn)->rc.rkey = m_res.mr->rkey;
@@ -878,6 +884,9 @@ void ReliableRDMA::initQPForSRQWithSuppliedID(size_t srq_id,
   struct ib_conn_t localConn;
   union ibv_gid my_gid;
   memset(&my_gid, 0, sizeof my_gid);
+  // context, port_num, index, gid
+  if (m_gidIdx != -1 && m_gidIdx <= m_res.port_attr.gid_tbl_len)
+    ibv_query_gid(m_res.ib_ctx, m_ibPort, m_gidIdx, &my_gid);
 
   localConn.buffer = (uint64_t)m_res.buffer;
   localConn.rc.rkey = m_res.mr->rkey;

--- a/src/rdma/UnreliableRDMA.cc
+++ b/src/rdma/UnreliableRDMA.cc
@@ -69,6 +69,10 @@ void UnreliableRDMA::initQPWithSuppliedID(const rdmaConnID rdmaConnID) {
   // create local connection data
   union ibv_gid my_gid;
   memset(&my_gid, 0, sizeof my_gid);
+  // context, port_num, index, gid
+  if (m_gidIdx != -1 && m_gidIdx <= m_res.port_attr.gid_tbl_len)
+    ibv_query_gid(m_res.ib_ctx, m_ibPort, m_gidIdx, &my_gid);
+
   qpConn->buffer = (uintptr_t)m_res.buffer;
   qpConn->qp_num = m_udqp.qp->qp_num;
   qpConn->lid = m_res.port_attr.lid;
@@ -116,6 +120,10 @@ void UnreliableRDMA::initQPWithSuppliedID(ib_qp_t** qpp, ib_conn_t** localcon) {
     // create local connection data
     union ibv_gid my_gid;
     memset(&my_gid, 0, sizeof my_gid);
+    // context, port_num, index, gid
+    if (m_gidIdx != -1 && m_gidIdx <= m_res.port_attr.gid_tbl_len)
+        ibv_query_gid(m_res.ib_ctx, m_ibPort, m_gidIdx, &my_gid);
+
     qpConn->buffer = (uintptr_t)m_res.buffer;
     qpConn->qp_num = m_udqp.qp->qp_num;
     qpConn->lid = m_res.port_attr.lid;

--- a/src/rdma/UnreliableRDMA.cc
+++ b/src/rdma/UnreliableRDMA.cc
@@ -167,6 +167,14 @@ void UnreliableRDMA::connectQP(const rdmaConnID rdmaConnID) {
   ah_attr.sl = 0;
   ah_attr.src_path_bits = 0;
   ah_attr.port_num = m_ibPort;
+  if (-1 != m_gidIdx) {
+    ah_attr.is_global = 1;
+    memcpy(&ah_attr.grh.dgid, m_rconns[rdmaConnID].gid, 16);
+    ah_attr.grh.flow_label = 0;
+    ah_attr.grh.hop_limit = 1;
+    ah_attr.grh.sgid_index = m_gidIdx;
+    ah_attr.grh.traffic_class = 0;
+  }
   struct ibv_ah* ah = ibv_create_ah(m_res.pd, &ah_attr);
   m_rconns[rdmaConnID].ud.ah = ah;
 

--- a/src/utils/Config.cc
+++ b/src/utils/Config.cc
@@ -32,6 +32,7 @@ size_t Config::RDMA_MEMSIZE = 1024ul * 1024 * 1024 * 5;  //1GB
 uint32_t Config::RDMA_NUMAREGION = 1;
 std::string Config::RDMA_DEVICE_FILE_PATH;
 uint32_t Config::RDMA_IBPORT = 1;
+uint32_t Config::RDMA_GID_INDEX = -1;
 uint32_t Config::RDMA_PORT = 5200;
 uint32_t Config::RDMA_MAX_WR = 4096;
 
@@ -145,6 +146,8 @@ void Config::set(string key, string value) {
     Config::RDMA_NUMAREGION = stoi(value);
   } else if (key.compare("RDMA_IBPORT") == 0) {
     Config::RDMA_IBPORT = stoi(value);
+  } else if (key.compare("RDMA_GID_INDEX") == 0) {
+    Config::RDMA_GID_INDEX = stoi(value);
   }else if (key.compare("LOGGING_LEVEL") == 0) {
     Config::LOGGING_LEVEL = stoi(value);
   }else if (key.compare("MLX5_SINGLE_THREADED") == 0) {

--- a/src/utils/Config.h
+++ b/src/utils/Config.h
@@ -71,6 +71,7 @@ class Config
     static uint32_t RDMA_NUMAREGION;
     static std::string RDMA_DEVICE_FILE_PATH;
     static uint32_t RDMA_IBPORT;
+    static uint32_t RDMA_GID_INDEX; // if set to -1 do not use the gid, else use the gid on the port with the given index
     static uint32_t RDMA_MAX_WR;
     const static uint32_t RDMA_MAX_SGE = 1;
     const static size_t RDMA_UD_OFFSET = 40;


### PR DESCRIPTION
Allow for using gid instead of or in combination with lid for addressing remote hosts (global/local id).
This also enables communication over RoCE when both communcation partner have the same lid.

Currently quickly tested with ReliableRDMA and UnreliableRDMA. 

EDIT: UC now tested also.