### PR TITLE
Add selecting rdma device by device name eg mlx5_0

### DIFF
--- a/src/rdma/BaseRDMA.cc
+++ b/src/rdma/BaseRDMA.cc
@@ -25,7 +25,7 @@ BaseRDMA::BaseRDMA(size_t mem_size) : BaseRDMA(mem_size, (int)Config::RDMA_NUMAR
 BaseRDMA::BaseRDMA(size_t mem_size, int numaNode) : m_numaNode(numaNode) {
   m_memSize = mem_size;
   m_ibPort = Config::RDMA_IBPORT;
-  m_gidIdx = Config::RDMA_GID_INDEX;
+  m_gidIdx = -1;
   m_rdmaMem.push_back(rdma_mem_t(m_memSize, true, 0));
 
   openIbDevice();

--- a/src/rdma/BaseRDMA.h
+++ b/src/rdma/BaseRDMA.h
@@ -147,6 +147,7 @@ class BaseRDMA {
  protected:
   virtual void destroyQPs() = 0;
 
+  void openIbDevice();
   // memory management
   void createBuffer();
 

--- a/src/utils/Config.cc
+++ b/src/utils/Config.cc
@@ -40,7 +40,7 @@ uint32_t Config::RDMA_UD_MTU = 4096;
 std::string Config::SEQUENCER_IP = "192.168.94.21"; //node02
 uint32_t Config::SEQUENCER_PORT = 5600;
 
-std::string Config::RDMA_DEV_NAME = ""; // e.g: mlx5_0, see also the names from ibv_devices or ibv_devinfo
+std::string Config::RDMA_DEV_NAME = ""; // e.g: mlx5_0, see also the names from ibv_devices or ibv_devinfo. If left empty the device will be selected based on numa region (RDMA_NUMAREGION).
 std::string Config::RDMA_INTERFACE = "ib1";
 
 uint32_t Config::MLX5_SINGLE_THREADED = 1;

--- a/src/utils/Config.cc
+++ b/src/utils/Config.cc
@@ -28,7 +28,7 @@ int Config::HELLO_PORT = 4001;
 
 
 //RDMA
-size_t Config::RDMA_MEMSIZE = 1024ul * 1024 * 1024 * 5;  //1GB
+size_t Config::RDMA_MEMSIZE = 1024ul * 1024 * 1024 * 5;  //5GB
 uint32_t Config::RDMA_NUMAREGION = 1;
 std::string Config::RDMA_DEVICE_FILE_PATH;
 uint32_t Config::RDMA_IBPORT = 1;
@@ -40,6 +40,7 @@ uint32_t Config::RDMA_UD_MTU = 4096;
 std::string Config::SEQUENCER_IP = "192.168.94.21"; //node02
 uint32_t Config::SEQUENCER_PORT = 5600;
 
+std::string Config::RDMA_DEV_NAME = ""; // e.g: mlx5_0, see also the names from ibv_devices or ibv_devinfo
 std::string Config::RDMA_INTERFACE = "ib1";
 
 uint32_t Config::MLX5_SINGLE_THREADED = 1;
@@ -151,6 +152,8 @@ void Config::set(string key, string value) {
     Config::MLX5_SINGLE_THREADED = stoi(value);
   }else if (key.compare("RDMA_INTERFACE") == 0) {
     Config::RDMA_INTERFACE = value;
+  }else if (key.compare("RDMA_DEV_NAME") == 0) {
+    Config::RDMA_DEV_NAME = value;
   }
 }
 

--- a/src/utils/Config.h
+++ b/src/utils/Config.h
@@ -84,6 +84,7 @@ class Config
     static uint32_t SEQUENCER_PORT;
 
     static std::string RDMA_INTERFACE;
+    static std::string RDMA_DEV_NAME;
 
     const static uint32_t MAX_RC_INLINE_SEND = 220;
     const static uint32_t MAX_UD_INLINE_SEND = 188;


### PR DESCRIPTION
Add selecting rdma device by device name (eg mlx5_0) instead of numa_node when intended 

Fix some SIGSEGV on the way regarding the order of freeing and selecting of devices.
Partly based on @Xiphoseer work from #13 